### PR TITLE
clarify phobos build steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Installation
 ============
 1. `git submodule update --init --recursive`
 2. Compile Phobos in the `phobos` submodule. Follow instructions there.
-3. `cd build ; cmake .. ; make ; cd ..`
+3. `mkdir build ; cd build ; cmake .. ; make ; cd ..` in main repo
 4. `./phobos/build/phobos flowscope.lua --help`
 
 FlowScope requires gcc 5 or later. You can use


### PR DESCRIPTION
Step 3 was missing `mkdir build`. Without that step spelled out it is rather confusing which build dir is meant.
